### PR TITLE
fix: backport regex change from 8.0.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const SPEC_ALGORITHMS = ['sha256', 'sha384', 'sha512']
 
 const BASE64_REGEX = /^[a-z0-9+/]+(?:=?=?)$/i
 const SRI_REGEX = /^([^-]+)-([^?]+)([?\S*]*)$/
-const STRICT_SRI_REGEX = /^([^-]+)-([A-Za-z0-9+/=]{44,88})(\?[\x21-\x7E]*)*$/
+const STRICT_SRI_REGEX = /^([^-]+)-([A-Za-z0-9+/=]{44,88})(\?[\x21-\x7E]*)?$/
 const VCHAR_REGEX = /^[\x21-\x7E]+$/
 
 const SsriOpts = figgyPudding({

--- a/test/parse.js
+++ b/test/parse.js
@@ -26,6 +26,34 @@ test('parses single-entry integrity string', t => {
   t.done()
 })
 
+test('parses options from integrity string', t => {
+  const sha = hash(TEST_DATA, 'sha512')
+  const integrity = `sha512-${sha}?one?two?three`
+  t.deepEqual(ssri.parse(integrity), {
+    sha512: [{
+      source: integrity,
+      digest: sha,
+      algorithm: 'sha512',
+      options: ['one', 'two', 'three']
+    }]
+  }, 'single entry parsed into full Integrity instance')
+  t.done()
+})
+
+test('parses options from integrity string in strict mode', t => {
+  const sha = hash(TEST_DATA, 'sha512')
+  const integrity = `sha512-${sha}?one?two?three`
+  t.deepEqual(ssri.parse(integrity, { strict: true }), {
+    sha512: [{
+      source: integrity,
+      digest: sha,
+      algorithm: 'sha512',
+      options: ['one', 'two', 'three']
+    }]
+  }, 'single entry parsed into full Integrity instance')
+  t.done()
+})
+
 test('can parse single-entry string directly into Hash', t => {
   const sha = hash(TEST_DATA, 'sha512')
   const integrity = `sha512-${sha}`


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Backport of #17 so it's easier for people to patch.

Once/if this is merged and released, the advisory will need to be updated to reflect the new vulnerability/fixed range to allow > 7.0.2

Relates to #19.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
