### PR TITLE
chore: add a year to LICENSE to match ISC format

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) npm, Inc.
+Copyright 2021 (c) npm, Inc.
 
 Permission to use, copy, modify, and/or distribute this software for
 any purpose with or without fee is hereby granted, provided that the


### PR DESCRIPTION
The ISC license should include a year in the Copyright as per https://opensource.org/licenses/ISC

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
