### PR TITLE
fix: properly handle missing algorithm type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -270,7 +270,10 @@ class Integrity {
   match (integrity, opts) {
     opts = ssriOpts(opts)
     const other = parse(integrity, opts)
-    const algo = other?.pickAlgorithm(opts)
+    if (!other) {
+      return false
+    }
+    const algo = other.pickAlgorithm(opts)
     return (
       this[algo] &&
       other[algo] &&

--- a/lib/index.js
+++ b/lib/index.js
@@ -270,7 +270,7 @@ class Integrity {
   match (integrity, opts) {
     opts = ssriOpts(opts)
     const other = parse(integrity, opts)
-    const algo = other.pickAlgorithm(opts)
+    const algo = other?.pickAlgorithm(opts)
     return (
       this[algo] &&
       other[algo] &&

--- a/test/integrity.js
+++ b/test/integrity.js
@@ -108,6 +108,7 @@ test('match()', t => {
   }, 'returns the strongest match')
   t.notOk(sri.match('sha512-foo'), 'falsy when match fails')
   t.notOk(sri.match('sha384-foo'), 'falsy when match fails')
+  t.notOk(sri.match(null), 'falsy when integrity is null')
   t.end()
 })
 


### PR DESCRIPTION
Fixing a bug that happen in npm cli when installing a library.

in Line 272 the result of parse can be null if integrity is null. Then in line 273 other is null so it breaks as below:
```
TypeError: Cannot read properties of null (reading 'pickAlgorithm')
npm verb stack     at Integrity.match (/usr/lib/node_modules/npm/node_modules/ssri/lib/index.js:273:24)
npm verb stack     at CachePolicy.satisfies (/usr/lib/node_modules/npm/node_modules/make-fetch-happen/lib/cache/policy.js:112:49)
npm verb stack     at Function.find (/usr/lib/node_modules/npm/node_modules/make-fetch-happen/lib/cache/entry.js:178:25)
npm verb stack     at async cacheFetch (/usr/lib/node_modules/npm/node_modules/make-fetch-happen/lib/cache/index.js:8:17)
npm verb stack     at async fetch (/usr/lib/node_modules/npm/node_modules/make-fetch-happen/lib/fetch.js:98:7)
```

```javascript
function parse (sri, opts) {
  if (!sri) {
    return null
  }
  opts = ssriOpts(opts)
  if (typeof sri === 'string') {
    return _parse(sri, opts)
  } else if (sri.algorithm && sri.digest) {
    const fullSri = new Integrity()
    fullSri[sri.algorithm] = [sri]
    return _parse(stringify(fullSri, opts), opts)
  } else {
    return _parse(stringify(sri, opts), opts)
  }
}
```
Here parse can return null if sri is not defined or null.
```javascript
  match (integrity, opts) {
    opts = ssriOpts(opts)
    const other = parse(integrity, opts)
    const algo = other.pickAlgorithm(opts) // HERE WHERE IT BREAKS
    return (
      this[algo] &&
      other[algo] &&
      this[algo].find(hash =>
        other[algo].find(otherhash =>
          hash.digest === otherhash.digest
        )
      )
    ) || false
  }
```
Here `const algo = other.pickAlgoritm(opts)` this where it breaks when `other = null`.
So we need to check whether other = null or not .
so a solution could be 
```javascript
const algo = other?.pickAlgorithm(opts) 
```
OR
```javascript
if(!other) return false;
const algo = other.pickAlgorithm(opts) 
```


<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

## Reference
[https://github.com/npm/cli/issues/5496](url)
[https://github.com/npm/cli/issues/3374](url)

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
