### PR TITLE
fix: remove spread opts and toString of integrity

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,33 +40,41 @@ class IntegrityStream extends MiniPass {
   constructor (opts) {
     super()
     this.size = 0
-    this.opts = opts
+    this.opts = opts || Object.create(null)
 
     // may be overridden later, but set now for class consistency
     this[_getOptions]()
 
     // options used for calculating stream.  can't be changed.
-    const algorithms = opts && opts.algorithms || defaultOpts.algorithms
-    this.algorithms = Array.from(
-      new Set(algorithms.concat(this.algorithm ? [this.algorithm] : []))
-    )
+    if (opts && opts.algorithms) {
+      const algorithms = opts.algorithms
+      this.algorithms = Array.from(
+        new Set(algorithms.concat(this.algorithm ? [this.algorithm] : []))
+      )
+    } else {
+      this.algorithms = defaultOpts.algorithms
+
+      if (this.algorithm !== null && this.algorithm !== defaultOpts.algorithms[0])
+        this.algorithms.push(this.algorithm);
+    }
+
     this.hashes = this.algorithms.map(crypto.createHash)
   }
 
   [_getOptions] () {
-    const {
-      integrity,
-      size,
-      options,
-    } = { ...defaultOpts, ...this.opts }
-
     // For verification
-    this.sri = integrity ? parse(integrity, this.opts) : null
-    this.expectedSize = size
-    this.goodSri = this.sri ? !!Object.keys(this.sri).length : false
-    this.algorithm = this.goodSri ? this.sri.pickAlgorithm(this.opts) : null
+    this.sri = this.opts.integrity ? parse(this.opts.integrity, this.opts) : null
+    this.expectedSize = this.opts.size
+    this.goodSri = this.sri instanceof Integrity 
+      ? !!Object.keys(this.sri).length 
+      : this.sri instanceof Hash
+    this.algorithm = this.goodSri 
+      ? this.sri instanceof Integrity
+        ? this.sri.pickAlgorithm(this.opts)
+        : this.sri.algorithm
+      : null
     this.digests = this.goodSri ? this.sri[this.algorithm] : null
-    this.optString = getOptString(options)
+    this.optString = getOptString(this.opts.options)
   }
 
   on (ev, handler) {
@@ -180,6 +188,17 @@ class Hash {
 
   toJSON () {
     return this.toString()
+  }
+
+  match (integrity, opts) {
+    const other = parse(integrity, opts)
+    if (!other) {
+      return false
+    }
+    const algo = other instanceof Integrity
+      ? other.pickAlgorithm(opts)
+      : other
+    return algo.digest === this.digest ? algo : false
   }
 
   toString (opts) {
@@ -433,7 +452,7 @@ function fromStream (stream, opts) {
       sri = s
     })
     istream.on('end', () => resolve(sri))
-    istream.on('data', () => {})
+    istream.resume()
   })
 }
 
@@ -500,7 +519,7 @@ function checkStream (stream, sri, opts) {
       verified = s
     })
     checker.on('end', () => resolve(verified))
-    checker.on('data', () => {})
+    checker.resume()
   })
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,11 @@
 const crypto = require('crypto')
 const MiniPass = require('minipass')
 
-const SPEC_ALGORITHMS = ['sha256', 'sha384', 'sha512']
+const SPEC_ALGORITHMS = {
+  'sha256': true, 
+  'sha384': true, 
+  'sha512': true
+};
 
 // TODO: this should really be a hardcoded list of algorithms we support,
 // rather than [a-z0-9].
@@ -21,8 +25,6 @@ const defaultOpts = {
   single: false,
   strict: false,
 }
-
-const ssriOpts = (opts = {}) => ({ ...defaultOpts, ...opts })
 
 const getOptString = options => !options || !options.length
   ? ''
@@ -44,7 +46,7 @@ class IntegrityStream extends MiniPass {
     this[_getOptions]()
 
     // options used for calculating stream.  can't be changed.
-    const { algorithms = defaultOpts.algorithms } = opts
+    const algorithms = opts && opts.algorithms || defaultOpts.algorithms
     this.algorithms = Array.from(
       new Set(algorithms.concat(this.algorithm ? [this.algorithm] : []))
     )
@@ -141,8 +143,7 @@ class Hash {
   }
 
   constructor (hash, opts) {
-    opts = ssriOpts(opts)
-    const strict = !!opts.strict
+    const strict = opts && opts.strict
     this.source = hash.trim()
 
     // set default values so that we make V8 happy to
@@ -161,7 +162,7 @@ class Hash {
     if (!match) {
       return
     }
-    if (strict && !SPEC_ALGORITHMS.some(a => a === match[1])) {
+    if (strict && SPEC_ALGORITHMS[match[1]] !== true) {
       return
     }
     this.algorithm = match[1]
@@ -182,14 +183,13 @@ class Hash {
   }
 
   toString (opts) {
-    opts = ssriOpts(opts)
-    if (opts.strict) {
+    if (opts && opts.strict) {
       // Strict mode enforces the standard as close to the foot of the
       // letter as it can.
       if (!(
         // The spec has very restricted productions for algorithms.
         // https://www.w3.org/TR/CSP2/#source-list-syntax
-        SPEC_ALGORITHMS.some(x => x === this.algorithm) &&
+        SPEC_ALGORITHMS[this.algorithm] === true &&
         // Usually, if someone insists on using a "different" base64, we
         // leave it as-is, since there's multiple standards, and the
         // specified is not a URL-safe variant.
@@ -224,8 +224,7 @@ class Integrity {
   }
 
   toString (opts) {
-    opts = ssriOpts(opts)
-    let sep = opts.sep || ' '
+    let sep = opts && opts.sep || ' '
     if (opts.strict) {
       // Entries must be separated by whitespace, according to spec.
       sep = sep.replace(/\S+/g, ' ')
@@ -238,7 +237,6 @@ class Integrity {
   }
 
   concat (integrity, opts) {
-    opts = ssriOpts(opts)
     const other = typeof integrity === 'string'
       ? integrity
       : stringify(integrity, opts)
@@ -252,7 +250,6 @@ class Integrity {
   // add additional hashes to an integrity value, but prevent
   // *changing* an existing integrity hash.
   merge (integrity, opts) {
-    opts = ssriOpts(opts)
     const other = parse(integrity, opts)
     for (const algo in other) {
       if (this[algo]) {
@@ -268,7 +265,6 @@ class Integrity {
   }
 
   match (integrity, opts) {
-    opts = ssriOpts(opts)
     const other = parse(integrity, opts)
     if (!other) {
       return false
@@ -286,8 +282,7 @@ class Integrity {
   }
 
   pickAlgorithm (opts) {
-    opts = ssriOpts(opts)
-    const pickAlgorithm = opts.pickAlgorithm
+    const pickAlgorithm = opts && opts.pickAlgorithm || defaultOpts.pickAlgorithm;
     const keys = Object.keys(this)
     return keys.reduce((acc, algo) => {
       return pickAlgorithm(acc, algo) || acc
@@ -300,7 +295,6 @@ function parse (sri, opts) {
   if (!sri) {
     return null
   }
-  opts = ssriOpts(opts)
   if (typeof sri === 'string') {
     return _parse(sri, opts)
   } else if (sri.algorithm && sri.digest) {
@@ -315,7 +309,7 @@ function parse (sri, opts) {
 function _parse (integrity, opts) {
   // 3.4.3. Parse metadata
   // https://w3c.github.io/webappsec-subresource-integrity/#parse-metadata
-  if (opts.single) {
+  if (opts && opts.single) {
     return new Hash(integrity, opts)
   }
   const hashes = integrity.trim().split(/\s+/).reduce((acc, string) => {
@@ -334,7 +328,6 @@ function _parse (integrity, opts) {
 
 module.exports.stringify = stringify
 function stringify (obj, opts) {
-  opts = ssriOpts(opts)
   if (obj.algorithm && obj.digest) {
     return Hash.prototype.toString.call(obj, opts)
   } else if (typeof obj === 'string') {
@@ -346,8 +339,7 @@ function stringify (obj, opts) {
 
 module.exports.fromHex = fromHex
 function fromHex (hexDigest, algorithm, opts) {
-  opts = ssriOpts(opts)
-  const optString = getOptString(opts.options)
+  const optString = getOptString(opts && opts.options)
   return parse(
     `${algorithm}-${
       Buffer.from(hexDigest, 'hex').toString('base64')
@@ -357,9 +349,8 @@ function fromHex (hexDigest, algorithm, opts) {
 
 module.exports.fromData = fromData
 function fromData (data, opts) {
-  opts = ssriOpts(opts)
-  const algorithms = opts.algorithms
-  const optString = getOptString(opts.options)
+  const algorithms = opts && opts.algorithms || defaultOpts.algorithms
+  const optString = getOptString(opts && opts.options)
   return algorithms.reduce((acc, algo) => {
     const digest = crypto.createHash(algo).update(data).digest('base64')
     const hash = new Hash(
@@ -382,7 +373,6 @@ function fromData (data, opts) {
 
 module.exports.fromStream = fromStream
 function fromStream (stream, opts) {
-  opts = ssriOpts(opts)
   const istream = integrityStream(opts)
   return new Promise((resolve, reject) => {
     stream.pipe(istream)
@@ -399,10 +389,9 @@ function fromStream (stream, opts) {
 
 module.exports.checkData = checkData
 function checkData (data, sri, opts) {
-  opts = ssriOpts(opts)
   sri = parse(sri, opts)
   if (!sri || !Object.keys(sri).length) {
-    if (opts.error) {
+    if (opts && opts.error) {
       throw Object.assign(
         new Error('No valid integrity hashes to check against'), {
           code: 'EINTEGRITY',
@@ -416,7 +405,8 @@ function checkData (data, sri, opts) {
   const digest = crypto.createHash(algorithm).update(data).digest('base64')
   const newSri = parse({ algorithm, digest })
   const match = newSri.match(sri, opts)
-  if (match || !opts.error) {
+  opts = opts || Object.create(null)
+  if (match || !(opts && opts.error)) {
     return match
   } else if (typeof opts.size === 'number' && (data.length !== opts.size)) {
     /* eslint-disable-next-line max-len */
@@ -440,7 +430,7 @@ function checkData (data, sri, opts) {
 
 module.exports.checkStream = checkStream
 function checkStream (stream, sri, opts) {
-  opts = ssriOpts(opts)
+  opts = opts || Object.create(null)
   opts.integrity = sri
   sri = parse(sri, opts)
   if (!sri || !Object.keys(sri).length) {
@@ -465,15 +455,14 @@ function checkStream (stream, sri, opts) {
 }
 
 module.exports.integrityStream = integrityStream
-function integrityStream (opts = {}) {
+function integrityStream (opts = Object.create(null)) {
   return new IntegrityStream(opts)
 }
 
 module.exports.create = createIntegrity
 function createIntegrity (opts) {
-  opts = ssriOpts(opts)
-  const algorithms = opts.algorithms
-  const optString = getOptString(opts.options)
+  const algorithms = opts && opts.algorithms || defaultOpts.algorithms
+  const optString = getOptString(opts && opts.options)
 
   const hashes = algorithms.map(crypto.createHash)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ class IntegrityStream extends MiniPass {
     this[_getOptions]()
 
     // options used for calculating stream.  can't be changed.
-    if (opts && opts.algorithms) {
+    if (opts?.algorithms) {
       const algorithms = opts.algorithms
       this.algorithms = Array.from(
         new Set(algorithms.concat(this.algorithm ? [this.algorithm] : []))
@@ -151,7 +151,7 @@ class Hash {
   }
 
   constructor (hash, opts) {
-    const strict = opts && opts.strict
+    const strict = opts?.strict
     this.source = hash.trim()
 
     // set default values so that we make V8 happy to
@@ -202,7 +202,7 @@ class Hash {
   }
 
   toString (opts) {
-    if (opts && opts.strict) {
+    if (opts?.strict) {
       // Strict mode enforces the standard as close to the foot of the
       // letter as it can.
       if (!(
@@ -278,10 +278,10 @@ class Integrity {
   }
 
   toString (opts) {
-    let sep = opts && opts.sep || ' '
+    let sep = opts?.sep || ' '
     let toString = '';
 
-    if (opts && opts.strict) {
+    if (opts?.strict) {
       // Entries must be separated by whitespace, according to spec.
       sep = sep.replace(/\S+/g, ' ')
 
@@ -351,7 +351,7 @@ class Integrity {
   }
 
   pickAlgorithm (opts) {
-    const pickAlgorithm = opts && opts.pickAlgorithm || defaultOpts.pickAlgorithm;
+    const pickAlgorithm = opts?.pickAlgorithm || defaultOpts.pickAlgorithm;
     const keys = Object.keys(this)
     return keys.reduce((acc, algo) => {
       return pickAlgorithm(acc, algo) || acc
@@ -378,7 +378,7 @@ function parse (sri, opts) {
 function _parse (integrity, opts) {
   // 3.4.3. Parse metadata
   // https://w3c.github.io/webappsec-subresource-integrity/#parse-metadata
-  if (opts && opts.single) {
+  if (opts?.single) {
     return new Hash(integrity, opts)
   }
   const hashes = integrity.trim().split(/\s+/).reduce((acc, string) => {
@@ -408,7 +408,7 @@ function stringify (obj, opts) {
 
 module.exports.fromHex = fromHex
 function fromHex (hexDigest, algorithm, opts) {
-  const optString = getOptString(opts && opts.options)
+  const optString = getOptString(opts?.options)
   return parse(
     `${algorithm}-${
       Buffer.from(hexDigest, 'hex').toString('base64')
@@ -418,8 +418,8 @@ function fromHex (hexDigest, algorithm, opts) {
 
 module.exports.fromData = fromData
 function fromData (data, opts) {
-  const algorithms = opts && opts.algorithms || defaultOpts.algorithms
-  const optString = getOptString(opts && opts.options)
+  const algorithms = opts?.algorithms || defaultOpts.algorithms
+  const optString = getOptString(opts?.options)
   return algorithms.reduce((acc, algo) => {
     const digest = crypto.createHash(algo).update(data).digest('base64')
     const hash = new Hash(
@@ -460,7 +460,7 @@ module.exports.checkData = checkData
 function checkData (data, sri, opts) {
   sri = parse(sri, opts)
   if (!sri || !Object.keys(sri).length) {
-    if (opts && opts.error) {
+    if (opts?.error) {
       throw Object.assign(
         new Error('No valid integrity hashes to check against'), {
           code: 'EINTEGRITY',
@@ -475,7 +475,7 @@ function checkData (data, sri, opts) {
   const newSri = parse({ algorithm, digest })
   const match = newSri.match(sri, opts)
   opts = opts || Object.create(null)
-  if (match || !(opts && opts.error)) {
+  if (match || !(opts?.error)) {
     return match
   } else if (typeof opts.size === 'number' && (data.length !== opts.size)) {
     /* eslint-disable-next-line max-len */
@@ -530,8 +530,8 @@ function integrityStream (opts = Object.create(null)) {
 
 module.exports.create = createIntegrity
 function createIntegrity (opts) {
-  const algorithms = opts && opts.algorithms || defaultOpts.algorithms
-  const optString = getOptString(opts && opts.options)
+  const algorithms = opts?.algorithms || defaultOpts.algorithms
+  const optString = getOptString(opts?.options)
 
   const hashes = algorithms.map(crypto.createHash)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -210,6 +210,41 @@ class Hash {
   }
 }
 
+function integrityHashToString(toString, sep, opts, hashes) {
+  if (!hashes || hashes.length === 0)
+    return toString;
+
+  const toStringIsNotEmpty = toString !== '';
+
+  let shouldAddFirstSep = false;
+  let complement = '';
+
+  const lastIndex = hashes.length - 1
+
+  for (let i = 0; i < lastIndex; i++) {
+    const hashString = Hash.prototype.toString.call(hashes[i], opts)
+
+    if (hashString) {
+      shouldAddFirstSep = true;
+
+      complement += hashString
+      complement += sep
+    }
+  }
+
+  const finalHashString = Hash.prototype.toString.call(hashes[lastIndex], opts)
+
+  if (finalHashString) {
+    shouldAddFirstSep = true;
+    complement += finalHashString
+  }
+
+  if (toStringIsNotEmpty && shouldAddFirstSep)
+    return toString + sep + complement;
+
+  return toString + complement 
+}
+
 class Integrity {
   get isIntegrity () {
     return true
@@ -225,15 +260,30 @@ class Integrity {
 
   toString (opts) {
     let sep = opts && opts.sep || ' '
-    if (opts.strict) {
+    let toString = '';
+
+    if (opts && opts.strict) {
       // Entries must be separated by whitespace, according to spec.
       sep = sep.replace(/\S+/g, ' ')
+
+      if (this.sha512 && this.sha512.length > 0) {
+        toString = integrityHashToString(toString, sep,opts, this['sha512'])
+      }
+
+      if (this.sha384 && this.sha384.length > 0) {
+        toString = integrityHashToString(toString, sep,opts, this['sha384'])
+      }
+
+      if (this.sha256 && this.sha256.length > 0) {
+        toString = integrityHashToString(toString,sep, opts, this['sha256'])
+      }
+    } else {
+      for (const hash of Object.keys(this)) {
+        toString = integrityHashToString(toString, sep,opts, this[hash])
+      }
     }
-    return Object.keys(this).map(k => {
-      return this[k].map(hash => {
-        return Hash.prototype.toString.call(hash, opts)
-      }).filter(x => x.length).join(sep)
-    }).filter(x => x.length).join(sep)
+
+    return toString;
   }
 
   concat (integrity, opts) {

--- a/test/check.js
+++ b/test/check.js
@@ -160,6 +160,9 @@ test('checkStream', t => {
     })
   }).then(res => {
     t.same(res, meta, 'Accepts Hash-like SRI')
+    return ssri.checkStream(fileStream(), `sha512-${hash(TEST_DATA, 'sha512')}`, { single: true })
+  }).then(res => {
+    t.same(res, meta, 'Process successfully with single option')
     return ssri.checkStream(
       fileStream(),
       `sha512-nope sha512-${hash(TEST_DATA, 'sha512')}`


### PR DESCRIPTION
<!-- What / Why -->
I was looking the CPU profiler of pnpm and I saw this call:

https://github.com/pnpm/pnpm/blob/ef6c22e129dc3d76998cee33647b70a66d1f36bf/store/cafs/src/getFilePathInCafs.ts#L29-L30

I thought about what I could do to optimize and then I found good performance improvements.

<!-- Describe the request in detail. What it does and why it's being changed. -->

## Removing spread of opts

The first thing I notice was the spread of `defaultOpts` in every method, sometimes being called twice without needing.
So remove all the calls, before this change:

```md
ssri.parse(base64, { single: true }) x 2,119,460 ops/sec ±1.93% (90 runs sampled)
ssri.parse(base64, { single: true, strict: true }) x 1,376,919 ops/sec ±0.93% (86 runs sampled)
ssri.parse(parsed, { single: true }) x 685,384 ops/sec ±0.91% (95 runs sampled)
ssri.parse(parsed, { single: true, strict: true }) x 448,575 ops/sec ±0.87% (95 runs sampled)
```

With the deletion of `opts`:

```md
ssri.parse(base64, { single: true }) x 4,928,681 ops/sec ±2.46% (85 runs sampled)
ssri.parse(base64, { single: true, strict: true }) x 2,339,789 ops/sec ±0.83% (96 runs sampled)
ssri.parse(parsed, { single: true }) x 1,531,463 ops/sec ±1.10% (88 runs sampled)
ssri.parse(parsed, { single: true, strict: true }) x 805,785 ops/sec ±1.24% (87 runs sampled)
```

<details>
<summary>benchmark.js</summary>

```js
const Benchmark = require('benchmark')
const ssri = require('./lib/index');
const suite = new Benchmark.Suite;
const fs = require('fs');
const crypto = require('crypto');

const TEST_DATA = fs.readFileSync(__filename)

function hash (data, algorithm) {
  return crypto.createHash(algorithm).update(data).digest('base64')
}

const sha = hash(TEST_DATA, 'sha512')
const integrity = `sha512-${sha}`;
const parsed = ssri.parse(integrity, { single: true });

suite
.add('ssri.parse(base64, { single: true })', function () {
  ssri.parse(integrity, { single: true })
})
.add('ssri.parse(base64, { single: true, strict: true })', function () {
  ssri.parse(integrity, { single: true, strict: true })
})
.add('ssri.parse(parsed, { single: true })', function () {
  ssri.parse(parsed, { single: true })
})
.add('ssri.parse(parsed, { single: true, strict: true })', function () {
  ssri.parse(parsed, { single: true, strict: true })
})
.on('cycle', function(event) {
  console.log(String(event.target))
})
.run({ 'async': false });
```

</details>

## Faster toString of Integrity

I look at a bunch of maps and filters and I just rewrite everything to perform the same operation without a bunch of loops.

With this optimization, we gain a little bit more performance:

```md
ssri.parse(base64, { single: true }) x 5,046,410 ops/sec ±0.98% (93 runs sampled)
ssri.parse(base64, { single: true, strict: true }) x 2,306,927 ops/sec ±1.26% (94 runs sampled)
ssri.parse(parsed, { single: true }) x 2,597,882 ops/sec ±1.19% (92 runs sampled)
ssri.parse(parsed, { single: true, strict: true }) x 1,005,282 ops/sec ±0.79% (96 runs sampled)
```

But with this change, I introduce a little breaking change, before, when calling `toString` of Integrity, the order of the hashes was defined by the order of the hashes during the insert/parsing.

Now, to optimize and avoid calling `Object.keys` on `strict` mode, I just call the properties directly, so the order will always be deterministic as: `sha512`, `sha384`, and `sha256`. If I change the order of these calls, the tests break.

If you think this is a problem, I can call `Object.keys` even in strict mode (-40k/ops).

## Faster integrity check when is stream

I also take a look at streams mode because PNPM also [verify the integrity of the files using streams](https://github.com/pnpm/pnpm/blob/ef6c22e129dc3d76998cee33647b70a66d1f36bf/fetching/tarball-fetcher/src/remoteTarballFetcher.ts#L204-L217).

The initial version was already fast compare to the main:

```
ssri.fromStream(stream, largeIntegrity) x 136 ops/sec ±3.17% (79 runs sampled)
ssri.fromStream(stream, tinyIntegrity) x 6,134 ops/sec ±2.32% (78 runs sampled)
ssri.checkStream(stream, largeIntegrity) x 150 ops/sec ±0.89% (77 runs sampled)
ssri.checkStream(stream, tinyIntegrity) x 8,121 ops/sec ±2.19% (78 runs sampled)
```

I also saw that `checkStream` doesn't support the option `single` and almost all verifications that are done by PNPM only verify a single hash, so I see an opportunity to push the performance a little bit further.

```
ssri.fromStream(stream, largeIntegrity) x 145 ops/sec ±1.86% (83 runs sampled)
ssri.fromStream(stream, tinyIntegrity) x 9,760 ops/sec ±2.97% (76 runs sampled)
ssri.checkStream(stream, largeIntegrity) x 150 ops/sec ±1.91% (77 runs sampled)
ssri.checkStream(stream, tinyIntegrity) x 9,024 ops/sec ±2.49% (76 runs sampled)

ssri.checkStream(stream, largeIntegrity, { single: true }) x 151 ops/sec ±1.10% (81 runs sampled)
ssri.checkStream(stream, tinyIntegrity, { single: true }) x 9,537 ops/sec ±1.64% (78 runs sampled)
```

But I did an experiment, If we ignore all the checkStream codes and jump to the final verification, we can achieve this performance:

```
ssri + createHash (largeIntegrity) x 343 ops/sec ±1.03% (82 runs sampled)
ssri + createHash (tinyIntegrity) x 17,360 ops/sec ±1.73% (79 runs sampled)
```

I put the code in the file above, the assumption is: if we verify only one hash, we can skip a lot of verifications.
So I think I could be good to `ssri` to export single hash verifications, what do you think?

<details>
<summary>benchmark-stream.js</summary>

```js
const Benchmark = require('benchmark');
// const wtf = require("wtfnode");
// wtf.init();
const ssri = require('./lib/index');
const suite = new Benchmark.Suite();
const fs = require('fs');
const crypto = require('crypto');
const { Readable } = require('stream');

const largeText = 'a'.repeat(64).repeat(100);
const largeTextSplitted = largeText.split('');

const tinyText = 'a'.repeat(64);
const tinyTextSplitted = tinyText.split('');

const getStream = (text) => Readable.from(text);

function hash(data, algorithm) {
  return crypto.createHash(algorithm).update(data).digest('base64');
}

const largeIntegrity = `sha512-${hash(largeText, 'sha512')}`;
const tinyIntegrity = `sha512-${hash(tinyText, 'sha512')}`;

suite
  .add('ssri.fromStream(stream, largeIntegrity)', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(largeTextSplitted);

      ssri.fromStream(stream, largeIntegrity).then(() => {
        deferred.resolve();
      });
    },
  })
  .add('ssri.fromStream(stream, tinyIntegrity)', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(tinyTextSplitted);

      ssri.fromStream(stream, tinyIntegrity).then(() => {
        deferred.resolve();
      });
    },
  })
  .add('ssri.checkStream(stream, largeIntegrity)', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(largeTextSplitted);

      ssri.checkStream(stream, largeIntegrity).then(() => {
        deferred.resolve();
      });
    },
  })
  .add('ssri.checkStream(stream, tinyIntegrity)', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(tinyTextSplitted);

      ssri.checkStream(stream, tinyIntegrity).then(() => {
        deferred.resolve();
      });
    },
  })
  .add('ssri.checkStream(stream, largeIntegrity, { single: true })', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(largeTextSplitted);

      ssri.checkStream(stream, largeIntegrity, { single: true }).then(() => {
        deferred.resolve();
      });
    },
  })
  .add('ssri.checkStream(stream, tinyIntegrity, { single: true })', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(tinyTextSplitted);

      ssri.checkStream(stream, tinyIntegrity, { single: true }).then(() => {
        deferred.resolve();
      });
    },
  })
  .add('ssri + createHash (largeIntegrity)', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(largeTextSplitted);
      const parsed = ssri.parse(largeIntegrity, { single: true });
      const hash = crypto.createHash(parsed.algorithm);

      stream.pipe(hash);
      stream.on('end', () => {
        const digest = hash.digest('base64');

        if (parsed.digest !== digest) {
          throw new Error('Integrity check failed');
        }
        deferred.resolve();
      });
    },
  })
  .add('ssri + createHash (tinyIntegrity)', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(tinyTextSplitted);
      const parsed = ssri.parse(tinyIntegrity, { single: true });
      const hash = crypto.createHash(parsed.algorithm);

      stream.pipe(hash);
      stream.on('end', () => {
        const digest = hash.digest('base64');

        if (parsed.digest !== digest) {
          throw new Error('Integrity check failed');
        }
        deferred.resolve();
      });
    },
  })
  .on('cycle', function (event) {
    console.log(String(event.target));
    // wtf.dump();
  })
  .run({ async: false });
```

</details>

In general, with these optimizations, we had a bump of more than 2x in performance.