### PR TITLE
fix: move from symbols to private methods

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,20 +15,18 @@ const VCHAR_REGEX = /^[\x21-\x7E]+$/
 
 const getOptString = options => options?.length ? `?${options.join('?')}` : ''
 
-const _onEnd = Symbol('_onEnd')
-const _getOptions = Symbol('_getOptions')
-const _emittedSize = Symbol('_emittedSize')
-const _emittedIntegrity = Symbol('_emittedIntegrity')
-const _emittedVerified = Symbol('_emittedVerified')
-
 class IntegrityStream extends MiniPass {
+  #emittedIntegrity
+  #emittedSize
+  #emittedVerified
+
   constructor (opts) {
     super()
     this.size = 0
     this.opts = opts
 
     // may be overridden later, but set now for class consistency
-    this[_getOptions]()
+    this.#getOptions()
 
     // options used for calculating stream.  can't be changed.
     const algorithms = opts?.algorithms || DEFAULT_ALGORITHMS
@@ -38,7 +36,7 @@ class IntegrityStream extends MiniPass {
     this.hashes = this.algorithms.map(crypto.createHash)
   }
 
-  [_getOptions] () {
+  #getOptions () {
     // For verification
     this.sri = this.opts?.integrity ? parse(this.opts?.integrity, this.opts) : null
     this.expectedSize = this.opts?.size
@@ -49,16 +47,16 @@ class IntegrityStream extends MiniPass {
   }
 
   on (ev, handler) {
-    if (ev === 'size' && this[_emittedSize]) {
-      return handler(this[_emittedSize])
+    if (ev === 'size' && this.#emittedSize) {
+      return handler(this.#emittedSize)
     }
 
-    if (ev === 'integrity' && this[_emittedIntegrity]) {
-      return handler(this[_emittedIntegrity])
+    if (ev === 'integrity' && this.#emittedIntegrity) {
+      return handler(this.#emittedIntegrity)
     }
 
-    if (ev === 'verified' && this[_emittedVerified]) {
-      return handler(this[_emittedVerified])
+    if (ev === 'verified' && this.#emittedVerified) {
+      return handler(this.#emittedVerified)
     }
 
     return super.on(ev, handler)
@@ -66,7 +64,7 @@ class IntegrityStream extends MiniPass {
 
   emit (ev, data) {
     if (ev === 'end') {
-      this[_onEnd]()
+      this.#onEnd()
     }
     return super.emit(ev, data)
   }
@@ -77,9 +75,9 @@ class IntegrityStream extends MiniPass {
     return super.write(data)
   }
 
-  [_onEnd] () {
+  #onEnd () {
     if (!this.goodSri) {
-      this[_getOptions]()
+      this.#getOptions()
     }
     const newSri = parse(this.hashes.map((h, i) => {
       return `${this.algorithms[i]}-${h.digest('base64')}${this.optString}`
@@ -104,12 +102,12 @@ class IntegrityStream extends MiniPass {
       err.sri = this.sri
       this.emit('error', err)
     } else {
-      this[_emittedSize] = this.size
+      this.#emittedSize = this.size
       this.emit('size', this.size)
-      this[_emittedIntegrity] = newSri
+      this.#emittedIntegrity = newSri
       this.emit('integrity', newSri)
       if (match) {
-        this[_emittedVerified] = match
+        this.#emittedVerified = match
         this.emit('verified', match)
       }
     }
@@ -381,7 +379,7 @@ function checkData (data, sri, opts) {
   const digest = crypto.createHash(algorithm).update(data).digest('base64')
   const newSri = parse({ algorithm, digest })
   const match = newSri.match(sri, opts)
-  opts = opts || Object.create(null)
+  opts = opts || {}
   if (match || !(opts.error)) {
     return match
   } else if (typeof opts.size === 'number' && (data.length !== opts.size)) {


### PR DESCRIPTION
Also reverted an `Object.create(null)` to `{}`