### PR TITLE
fix: faster toString for integrity

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 const crypto = require('crypto')
 const MiniPass = require('minipass')
 
-const SPEC_ALGORITHMS = ['sha256', 'sha384', 'sha512']
+const SPEC_ALGORITHMS = ['sha512', 'sha384', 'sha256']
 const DEFAULT_ALGORITHMS = ['sha512']
 
 // TODO: this should really be a hardcoded list of algorithms we support,
@@ -186,6 +186,39 @@ class Hash {
   }
 }
 
+function integrityHashToString (toString, sep, opts, hashes) {
+  const toStringIsNotEmpty = toString !== ''
+
+  let shouldAddFirstSep = false
+  let complement = ''
+
+  const lastIndex = hashes.length - 1
+
+  for (let i = 0; i < lastIndex; i++) {
+    const hashString = Hash.prototype.toString.call(hashes[i], opts)
+
+    if (hashString) {
+      shouldAddFirstSep = true
+
+      complement += hashString
+      complement += sep
+    }
+  }
+
+  const finalHashString = Hash.prototype.toString.call(hashes[lastIndex], opts)
+
+  if (finalHashString) {
+    shouldAddFirstSep = true
+    complement += finalHashString
+  }
+
+  if (toStringIsNotEmpty && shouldAddFirstSep) {
+    return toString + sep + complement
+  }
+
+  return toString + complement
+}
+
 class Integrity {
   get isIntegrity () {
     return true
@@ -201,15 +234,24 @@ class Integrity {
 
   toString (opts) {
     let sep = opts?.sep || ' '
+    let toString = ''
+
     if (opts?.strict) {
       // Entries must be separated by whitespace, according to spec.
       sep = sep.replace(/\S+/g, ' ')
+
+      for (const hash of SPEC_ALGORITHMS) {
+        if (this[hash]) {
+          toString = integrityHashToString(toString, sep, opts, this[hash])
+        }
+      }
+    } else {
+      for (const hash of Object.keys(this)) {
+        toString = integrityHashToString(toString, sep, opts, this[hash])
+      }
     }
-    return Object.keys(this).map(k => {
-      return this[k].map(hash => {
-        return Hash.prototype.toString.call(hash, opts)
-      }).filter(x => x.length).join(sep)
-    }).filter(x => x.length).join(sep)
+
+    return toString
   }
 
   concat (integrity, opts) {


### PR DESCRIPTION
<!-- What / Why -->

<!-- Describe the request in detail. What it does and why it's being changed. -->

Performance before:

```
parsed.toString() x 1,595,186 ops/sec ±1.35% (90 runs sampled)
parsedStrict.toString() x 1,553,016 ops/sec ±1.82% (90 runs sampled)
```

After:

```
parsed.toString() x 8,128,007 ops/sec ±1.82% (90 runs sampled)
parsedStrict.toString() x 8,322,286 ops/sec ±1.30% (93 runs sampled)
```

<details>
<summary>benchmark.js</summary>

```js
const Benchmark = require('benchmark')
const ssri = require('./lib/index');
const suite = new Benchmark.Suite;

const integrity = `sha512-WrLorGiX4iEWOOOaJSiCrmDIamA47exH+Bz7tVwIPb4sCU8w4iNqGCqYuspMMeU5pgz/sU7koP5u8W3RCUojGw== sha256-Qhx213Vjr6GRSEawEL0WTzlb00whAuXpngy5zxc8HYc=`;
const parsed = ssri.parse(integrity);
const parsedStrict = ssri.parse(integrity, { strict: true });

suite
.add('parsed.toString()', function () {
  parsed.toString()
})
.add('parsedStrict.toString()', function () {
  parsedStrict.toString()
})
.on('cycle', function(event) {
  console.log(String(event.target))
})
.run({ 'async': false });
```

</details>

When parsing is `strict`, I introduce a small break change because I know the possible hashes, so I call it directly.
Instead of the toString being stringified in the order in which the hashes were added, it will always be stringified in this order: sha512, sha384 and sha256.

If you think that is problematic, we can keep the loop, even if is a little bit slower.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Related to #71

