### PR TITLE
fix: faster stream verification

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,10 +29,18 @@ class IntegrityStream extends MiniPass {
     this.#getOptions()
 
     // options used for calculating stream.  can't be changed.
-    const algorithms = opts?.algorithms || DEFAULT_ALGORITHMS
-    this.algorithms = Array.from(
-      new Set(algorithms.concat(this.algorithm ? [this.algorithm] : []))
-    )
+    if (opts?.algorithms) {
+      this.algorithms = Array.from(
+        new Set(opts.algorithms.concat(this.algorithm ? [this.algorithm] : []))
+      )
+    } else {
+      this.algorithms = DEFAULT_ALGORITHMS
+
+      if (this.algorithm !== null && this.algorithm !== DEFAULT_ALGORITHMS[0]) {
+        this.algorithms.push(this.algorithm)
+      }
+    }
+
     this.hashes = this.algorithms.map(crypto.createHash)
   }
 
@@ -40,8 +48,20 @@ class IntegrityStream extends MiniPass {
     // For verification
     this.sri = this.opts?.integrity ? parse(this.opts?.integrity, this.opts) : null
     this.expectedSize = this.opts?.size
-    this.goodSri = this.sri ? !!Object.keys(this.sri).length : false
-    this.algorithm = this.goodSri ? this.sri.pickAlgorithm(this.opts) : null
+
+    if (!this.sri) {
+      this.algorithm = null
+    } else if (this.sri.isIntegrity) {
+      this.goodSri = !this.sri.isEmpty()
+
+      if (this.goodSri) {
+        this.algorithm = this.sri.pickAlgorithm(this.opts)
+      }
+    } else if (this.sri.isHash) {
+      this.goodSri = true
+      this.algorithm = this.sri.algorithm
+    }
+
     this.digests = this.goodSri ? this.sri[this.algorithm] : null
     this.optString = getOptString(this.opts?.options)
   }
@@ -157,6 +177,24 @@ class Hash {
 
   toJSON () {
     return this.toString()
+  }
+
+  match (integrity, opts) {
+    const other = parse(integrity, opts)
+    if (!other) {
+      return false
+    }
+    if (other instanceof Integrity) {
+      const algo = other.pickAlgorithm(opts)
+      const foundHash = other[algo].find(hash => hash.digest === this.digest)
+
+      if (foundHash) {
+        return foundHash
+      }
+
+      return false
+    }
+    return other.digest === this.digest ? other : false
   }
 
   toString (opts) {
@@ -399,7 +437,7 @@ function fromStream (stream, opts) {
       sri = s
     })
     istream.on('end', () => resolve(sri))
-    istream.on('data', () => {})
+    istream.resume()
   })
 }
 
@@ -466,7 +504,7 @@ function checkStream (stream, sri, opts) {
       verified = s
     })
     checker.on('end', () => resolve(verified))
-    checker.on('data', () => {})
+    checker.resume()
   })
 }
 

--- a/test/check.js
+++ b/test/check.js
@@ -160,6 +160,9 @@ test('checkStream', t => {
     })
   }).then(res => {
     t.same(res, meta, 'Accepts Hash-like SRI')
+    return ssri.checkStream(fileStream(), `sha512-${hash(TEST_DATA, 'sha512')}`, { single: true })
+  }).then(res => {
+    t.same(res, meta, 'Process successfully with single option')
     return ssri.checkStream(
       fileStream(),
       `sha512-nope sha512-${hash(TEST_DATA, 'sha512')}`

--- a/test/match.js
+++ b/test/match.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const crypto = require('crypto')
+const fs = require('fs')
+const test = require('tap').test
+
+const ssri = require('..')
+
+const TEST_DATA = fs.readFileSync(__filename)
+
+function hash (data, algorithm) {
+  return crypto.createHash(algorithm).update(data).digest('base64')
+}
+
+test('hashes should match when valid', t => {
+  const sha = hash(TEST_DATA, 'sha512')
+  const integrity = `sha512-${sha}`
+  const parsed = ssri.parse(integrity, { single: true })
+  t.same(
+    parsed.match(integrity, { single: true }),
+    parsed,
+    'should return the same algo when digest is equal (single option)'
+  )
+  t.same(
+    parsed.match('sha-233', { single: true }),
+    false,
+    'invalid integrity should not match (single option)'
+  )
+  t.same(
+    parsed.match(null, { single: true }),
+    false,
+    'null integrity just returns false (single option)'
+  )
+
+  t.same(
+    parsed.match(integrity),
+    parsed,
+    'should return the same algo when digest is equal'
+  )
+  t.same(
+    parsed.match('sha-233'),
+    false,
+    'invalid integrity should not match'
+  )
+  t.same(
+    parsed.match(null),
+    false,
+    'null integrity just returns false'
+  )
+  t.end()
+})


### PR DESCRIPTION
## Faster integrity check when is stream

I also take a look at streams mode because PNPM also [verify the integrity of the files using streams](https://github.com/pnpm/pnpm/blob/ef6c22e129dc3d76998cee33647b70a66d1f36bf/fetching/tarball-fetcher/src/remoteTarballFetcher.ts#L204-L217).

The initial version was already fast compare to the main:

```
sri.fromStream(stream, largeIntegrity) x 145 ops/sec ±1.58% (78 runs sampled)
ssri.fromStream(stream, tinyIntegrity) x 9,508 ops/sec ±2.53% (76 runs sampled)
ssri.checkStream(stream, largeIntegrity) x 153 ops/sec ±0.92% (78 runs sampled)
ssri.checkStream(stream, tinyIntegrity) x 9,055 ops/sec ±1.81% (80 runs sampled)
```

I also saw that `checkStream` doesn't support the option `single` and almost all verifications that are done by PNPM only verify a single hash, so I see an opportunity to push the performance a little bit further.

```
ssri.fromStream(stream, largeIntegrity) x 147 ops/sec ±1.76% (76 runs sampled)
ssri.fromStream(stream, tinyIntegrity) x 10,339 ops/sec ±2.71% (80 runs sampled)
ssri.checkStream(stream, largeIntegrity) x 152 ops/sec ±1.14% (80 runs sampled)
ssri.checkStream(stream, tinyIntegrity) x 10,023 ops/sec ±1.46% (81 runs sampled)

ssri.checkStream(stream, largeIntegrity, { single: true }) x 151 ops/sec ±1.19% (79 runs sampled)
ssri.checkStream(stream, tinyIntegrity, { single: true }) x 10,278 ops/sec ±1.35% (81 runs sampled)
```

But I did an experiment, If we ignore all the checkStream codes and jump to the final verification, we can achieve this performance:

```
ssri + createHash (largeIntegrity) x 318 ops/sec ±1.52% (81 runs sampled)
ssri + createHash (tinyIntegrity) x 15,863 ops/sec ±1.70% (81 runs sampled)
```

I put the code in the file above, the assumption is: if we verify only one hash, we can skip a lot of verifications.
So I think I could be good to `ssri` to export single hash verifications, what do you think?

<details>
<summary>benchmark-stream.js</summary>

```js
const Benchmark = require('benchmark');
// const wtf = require("wtfnode");
// wtf.init();
const ssri = require('./lib/index');
const suite = new Benchmark.Suite();
const fs = require('fs');
const crypto = require('crypto');
const { Readable } = require('stream');

const largeText = 'a'.repeat(64).repeat(100);
const largeTextSplitted = largeText.split('');

const tinyText = 'a'.repeat(64);
const tinyTextSplitted = tinyText.split('');

const getStream = (text) => Readable.from(text);

function hash(data, algorithm) {
  return crypto.createHash(algorithm).update(data).digest('base64');
}

const largeIntegrity = `sha512-${hash(largeText, 'sha512')}`;
const tinyIntegrity = `sha512-${hash(tinyText, 'sha512')}`;

suite
  .add('ssri.fromStream(stream, largeIntegrity)', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(largeTextSplitted);

      ssri.fromStream(stream, largeIntegrity).then(() => {
        deferred.resolve();
      });
    },
  })
  .add('ssri.fromStream(stream, tinyIntegrity)', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(tinyTextSplitted);

      ssri.fromStream(stream, tinyIntegrity).then(() => {
        deferred.resolve();
      });
    },
  })
  .add('ssri.checkStream(stream, largeIntegrity)', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(largeTextSplitted);

      ssri.checkStream(stream, largeIntegrity).then(() => {
        deferred.resolve();
      });
    },
  })
  .add('ssri.checkStream(stream, tinyIntegrity)', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(tinyTextSplitted);

      ssri.checkStream(stream, tinyIntegrity).then(() => {
        deferred.resolve();
      });
    },
  })
  .add('ssri.checkStream(stream, largeIntegrity, { single: true })', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(largeTextSplitted);

      ssri.checkStream(stream, largeIntegrity, { single: true }).then(() => {
        deferred.resolve();
      });
    },
  })
  .add('ssri.checkStream(stream, tinyIntegrity, { single: true })', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(tinyTextSplitted);

      ssri.checkStream(stream, tinyIntegrity, { single: true }).then(() => {
        deferred.resolve();
      });
    },
  })
  .add('ssri + createHash (largeIntegrity)', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(largeTextSplitted);
      const parsed = ssri.parse(largeIntegrity, { single: true });
      const hash = crypto.createHash(parsed.algorithm);

      stream.pipe(hash);
      stream.on('end', () => {
        const digest = hash.digest('base64');

        if (parsed.digest !== digest) {
          throw new Error('Integrity check failed');
        }
        deferred.resolve();
      });
    },
  })
  .add('ssri + createHash (tinyIntegrity)', {
    defer: true,
    fn: function (deferred) {
      const stream = getStream(tinyTextSplitted);
      const parsed = ssri.parse(tinyIntegrity, { single: true });
      const hash = crypto.createHash(parsed.algorithm);

      stream.pipe(hash);
      stream.on('end', () => {
        const digest = hash.digest('base64');

        if (parsed.digest !== digest) {
          throw new Error('Integrity check failed');
        }
        deferred.resolve();
      });
    },
  })
  .on('cycle', function (event) {
    console.log(String(event.target));
    // wtf.dump();
  })
  .run({ async: false });
```

</details>


## References

Related to #71

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
