### PR TITLE
Address breaking engine change in dependency

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -87,21 +87,15 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 14.17.0
-          - 14.x
-          - 16.13.0
+          - 16.14.0
           - 16.x
           - 18.0.0
           - 18.x
           - 20.x
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-latest, shell: bash }
-            node-version: 14.17.0
-          - platform: { name: macOS, os: macos-latest, shell: bash }
-            node-version: 14.x
           - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 16.13.0
+            node-version: 16.14.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 16.x
           - platform: { name: macOS, os: macos-13, shell: bash }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,21 +64,15 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 14.17.0
-          - 14.x
-          - 16.13.0
+          - 16.14.0
           - 16.x
           - 18.0.0
           - 18.x
           - 20.x
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-latest, shell: bash }
-            node-version: 14.17.0
-          - platform: { name: macOS, os: macos-latest, shell: bash }
-            node-version: 14.x
           - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 16.13.0
+            node-version: 16.14.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 16.x
           - platform: { name: macOS, os: macos-13, shell: bash }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "tap": "^16.0.1"
   },
   "engines": {
-    "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+    "node": "^16.14.0 || >=18.0.0"
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

node 14.17.0 no longer works due to `node` prefixes being added in https://github.com/isaacs/minipass/commit/1270e6ac685fbc527fd43dd57e95c9a171f11bea

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

node 14.17.0 build break: https://github.com/npm/ssri/actions/runs/10049925593/job/27776871923